### PR TITLE
Allow urlencoded names with whitespace

### DIFF
--- a/indy-didresolver/Cargo.toml
+++ b/indy-didresolver/Cargo.toml
@@ -16,6 +16,7 @@ serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
 url = "2.2.2"
+urlencoding = "2.1.0"
 
 [dev-dependencies]
 rstest = "0.12"

--- a/indy-didresolver/src/did.rs
+++ b/indy-didresolver/src/did.rs
@@ -2,6 +2,7 @@ use super::error::{DidIndyError, DidIndyResult};
 use indy_vdr::utils::did::DidValue;
 use regex::Regex;
 use url::Url;
+use urlencoding::decode;
 
 use std::collections::HashMap;
 
@@ -16,7 +17,7 @@ static OBJECT_FAMILY_VERSION_PATTERN: &str = "([a-zA-Z0-9]*)";
 static ANONCREDSV0_OBJECTS_PATTERN: &str =
     "(SCHEMA|CLAIM_DEF|REV_REG_DEF|REV_REG_ENTRY|REV_REG_DELTA)";
 
-static CLIENT_DEFINED_NAME_PATTERN: &str = "([\\w-]*)";
+static CLIENT_DEFINED_NAME_PATTERN: &str = "([\\w -]*)";
 static SEQ_NO_PATTERN: &str = "(\\d*)";
 static VERSION_PATTERN: &str = "((\\d*\\.){1,2}\\d*)";
 
@@ -283,7 +284,7 @@ impl DidUrl {
                 let did = DidUrl {
                     namespace: cap.get(1).unwrap().as_str().to_string(),
                     id: DidValue::new(cap.get(2).unwrap().as_str(), Option::None),
-                    path: cap.get(3).and_then(|p| Some(p.as_str().to_string())),
+                    path: cap.get(3).and_then(|p| Some(decode(p.as_str()).unwrap().to_string())),
                     query: query_pairs,
                     url: input.to_string(),
                 };


### PR DESCRIPTION
Even if the did indy method spec will provide stricter rules on client-defined names, we'll still need to resolve legacy ledger objects with names containing white spaces. This PR allows the resolution of such ledger objects, when the name in the DID Url path is URL encoded.

Signed-off-by: Dominic Wörner <dom.woe@gmail.com>